### PR TITLE
Factorize scenario creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ which can be access via the `infra` property.
 ### CLI reference
 
 ```
-Usage: ppi [-hV] [--np=<number>] [-s=<path>] <process-class> <runner-class>
-           [<args>...]
+Usage: ppi [-s=<path> | -c=<json>] [-hV] [--np=<number>] <process-class>
+           <runner-class> [<args>...]
       <process-class>     Fully qualified name of the class to use as process
       <runner-class>      Fully qualified name of the class to use as runner
       [<args>...]         Args to pass to the processes
+  -c, --content=<json>    Content of the scenario
   -h, --help              Display a help message
       --np=<number>       Number of processus in the network
                             Default: 4

--- a/src/main/java/org/sar/ppi/Runner.java
+++ b/src/main/java/org/sar/ppi/Runner.java
@@ -1,6 +1,6 @@
 package org.sar.ppi;
 
-import java.io.File;
+import org.sar.ppi.events.Scenario;
 
 /**
  * Runner Interface. It is run by Ppi to start the Infractructure.
@@ -12,8 +12,8 @@ public interface Runner {
 	 * @param pClass   the class to execute by Ppi.
 	 * @param args     the args to pass to the processes.
 	 * @param nbProcs  the number of processes to run.
-	 * @param scenario the name of the scenario file.
+	 * @param scenario the scenario to execute.
 	 * @throws java.lang.ReflectiveOperationException if pClass instanciation fails.
 	 */
-	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, File scenario) throws ReflectiveOperationException;
+	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, Scenario scenario) throws ReflectiveOperationException;
 }

--- a/src/main/java/org/sar/ppi/events/Call.java
+++ b/src/main/java/org/sar/ppi/events/Call.java
@@ -1,5 +1,7 @@
 package org.sar.ppi.events;
 
+import java.util.Arrays;
+
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 public class Call extends ScheduledEvent {
@@ -32,5 +34,11 @@ public class Call extends ScheduledEvent {
 			classes[i] = args[i].getClass();
 		}
 		return classes;
+	}
+
+	@Override
+	public String toString() {
+		String args = Arrays.toString(this.args);
+		return "call(" +super.toString() + ", function:" + function + ", args:" + args + ")";
 	}
 }

--- a/src/main/java/org/sar/ppi/events/Deploy.java
+++ b/src/main/java/org/sar/ppi/events/Deploy.java
@@ -2,4 +2,9 @@ package org.sar.ppi.events;
 
 public class Deploy extends ScheduledEvent {
 	private static final long serialVersionUID = 1L;
+
+	@Override
+	public String toString() {
+		return "depoy(" + super.toString() + ")";
+	}
 }

--- a/src/main/java/org/sar/ppi/events/Scenario.java
+++ b/src/main/java/org/sar/ppi/events/Scenario.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
+import org.sar.ppi.tools.Utils;
+
 public class Scenario {
 	@JsonProperty(value = "$schema", access = JsonProperty.Access.WRITE_ONLY)
 	private String schema = "";
@@ -51,16 +53,7 @@ public class Scenario {
 
 	@JsonIgnore
 	public ScheduledEvent[] getEvents() {
-		int pos = 0;
-		int size = deploys.length + undeploys.length + calls.length;
-		ScheduledEvent[] events = new ScheduledEvent[size];
-		System.arraycopy(deploys, 0, events, pos, deploys.length);
-		pos += deploys.length;
-		System.arraycopy(undeploys, 0, events, pos, undeploys.length);
-		pos += undeploys.length;
-		System.arraycopy(calls, 0, events, pos, calls.length);
-		pos += calls.length;
-		return events;
+		return Utils.concatAll(ScheduledEvent.class, deploys, undeploys, calls);
 	}
 
 	@JsonIgnore

--- a/src/main/java/org/sar/ppi/events/Scenario.java
+++ b/src/main/java/org/sar/ppi/events/Scenario.java
@@ -1,5 +1,7 @@
 package org.sar.ppi.events;
 
+import java.util.Arrays;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
@@ -64,5 +66,13 @@ public class Scenario {
 	@JsonIgnore
 	public boolean isEmpty() {
 		return deploys.length == 0 && undeploys.length == 0 && calls.length == 0;
+	}
+
+	@Override
+	public String toString() {
+		String d = Arrays.toString(deploys);
+		String u = Arrays.toString(undeploys);
+		String c = Arrays.toString(calls);
+		return "scenario(deploys:" + d + ", undeploys:" + u + ", calls:" + c + ")";
 	}
 }

--- a/src/main/java/org/sar/ppi/events/Scenario.java
+++ b/src/main/java/org/sar/ppi/events/Scenario.java
@@ -1,11 +1,12 @@
 package org.sar.ppi.events;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 public class Scenario {
-	@JsonProperty("$schema")
+	@JsonProperty(value = "$schema", access = JsonProperty.Access.WRITE_ONLY)
 	private String schema = "";
 
 	@JsonPropertyDescription("The list of Deploy events")
@@ -26,14 +27,27 @@ public class Scenario {
 		this.deploys = deploys;
 	}
 
+	public Deploy[] getDeploys() {
+		return deploys;
+	}
+
 	public void setUndeploys(Undeploy[] undeploys) {
 		this.undeploys = undeploys;
+	}
+
+	public Undeploy[] getUndeploys() {
+		return undeploys;
 	}
 
 	public void setCalls(Call[] calls) {
 		this.calls = calls;
 	}
 
+	public Call[] getCalls() {
+		return calls;
+	}
+
+	@JsonIgnore
 	public ScheduledEvent[] getEvents() {
 		int pos = 0;
 		int size = deploys.length + undeploys.length + calls.length;
@@ -45,5 +59,10 @@ public class Scenario {
 		System.arraycopy(calls, 0, events, pos, calls.length);
 		pos += calls.length;
 		return events;
+	}
+
+	@JsonIgnore
+	public boolean isEmpty() {
+		return deploys.length == 0 && undeploys.length == 0 && calls.length == 0;
 	}
 }

--- a/src/main/java/org/sar/ppi/events/ScheduledEvent.java
+++ b/src/main/java/org/sar/ppi/events/ScheduledEvent.java
@@ -26,4 +26,9 @@ public abstract class ScheduledEvent implements Event {
 	public int getDelay() {
 		return delay;
 	}
+
+	@Override
+	public String toString() {
+		return "node:" + node + ", delay:" + delay;
+	}
 }

--- a/src/main/java/org/sar/ppi/events/Undeploy.java
+++ b/src/main/java/org/sar/ppi/events/Undeploy.java
@@ -2,4 +2,9 @@ package org.sar.ppi.events;
 
 public class Undeploy extends ScheduledEvent {
 	private static final long serialVersionUID = 1L;
+
+	@Override
+	public String toString() {
+		return "undepoy(" + super.toString() + ")";
+	}
 }

--- a/src/main/java/org/sar/ppi/mpi/MpiRunner.java
+++ b/src/main/java/org/sar/ppi/mpi/MpiRunner.java
@@ -14,6 +14,7 @@ import org.sar.ppi.Ppi;
 import org.sar.ppi.PpiException;
 import org.sar.ppi.Runner;
 import org.sar.ppi.events.Scenario;
+import org.sar.ppi.tools.Utils;
 
 /**
  * MpiRunner class.
@@ -32,7 +33,7 @@ public class MpiRunner implements Runner {
 		} catch (JsonProcessingException e) {
 			throw new PpiException("Could not serialize this scenario", e);
 		}
-		ProcessBuilder pBuilder = new ProcessBuilder(
+		String[] cmdline = new String[] {
 			"mpirun",
 			"--oversubscribe",
 			"--np",
@@ -44,12 +45,12 @@ public class MpiRunner implements Runner {
 			pClass.getName(),
 			MpiSubRunner.class.getName(),
 			"--np=" + nbProcs,
-			"-c=" + scenarioJson,
-			String.join(" ", args)
-		);
-		logger.debug("mpi cmdline: {}", pBuilder.command());
+			"-c=" + scenarioJson
+		};
+		cmdline = Utils.concatAll(String.class, cmdline, args);
+		logger.debug("mpi cmdline: {}", String.join(" ", cmdline));
 		try {
-			Process p = pBuilder.start();
+			Process p = Runtime.getRuntime().exec(cmdline);
 			Thread killMpi = new Thread(() -> {
 				System.out.println("Interrupt received, killing MPI");
 				p.destroyForcibly();

--- a/src/main/java/org/sar/ppi/mpi/MpiSubRunner.java
+++ b/src/main/java/org/sar/ppi/mpi/MpiSubRunner.java
@@ -1,9 +1,8 @@
 package org.sar.ppi.mpi;
 
-import java.io.File;
-
 import org.sar.ppi.NodeProcess;
 import org.sar.ppi.Runner;
+import org.sar.ppi.events.Scenario;
 
 /**
  * MpiSubRunner class.
@@ -12,7 +11,7 @@ public class MpiSubRunner implements Runner {
 
 	/** {@inheritDoc} */
 	@Override
-	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, File scenario)
+	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, Scenario scenario)
 			throws ReflectiveOperationException {
 		NodeProcess process = pClass.newInstance();
 		MpiInfrastructure infra;

--- a/src/main/java/org/sar/ppi/peersim/PeerSimInit.java
+++ b/src/main/java/org/sar/ppi/peersim/PeerSimInit.java
@@ -1,7 +1,6 @@
 package org.sar.ppi.peersim;
 
-import org.sar.ppi.PpiException;
-import org.sar.ppi.events.Scenario;
+import org.sar.ppi.Ppi;
 import org.sar.ppi.events.ScheduledEvent;
 import peersim.config.Configuration;
 import peersim.config.MissingParameterException;
@@ -11,11 +10,6 @@ import peersim.core.Network;
 import peersim.core.Node;
 import peersim.edsim.EDSimulator;
 import peersim.util.ExtendedRandom;
-
-import java.io.File;
-import java.io.IOException;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * PeerSimInit class.
@@ -29,7 +23,6 @@ public class PeerSimInit implements Control {
 	private final int infrapid;
 
 	private  int pid_trans;
-	private String FileName;
 
 	/**
 	 * Constructor for PeerSimInit.
@@ -40,10 +33,8 @@ public class PeerSimInit implements Control {
 		infrapid=Configuration.getPid(prefix+"."+PAR_PROTO);
 		try{
 		pid_trans=Configuration.getPid(prefix+"."+TRANSPORT_SIMULATION);
-		FileName = Configuration.getString("path");
 		}catch (MissingParameterException e){
 			pid_trans=-1;
-			FileName=null;
 		}
 	}
 
@@ -59,25 +50,12 @@ public class PeerSimInit implements Control {
 			PeerSimInfrastructure pInfra = (PeerSimInfrastructure) node.getProtocol(infrapid);
 			pInfra.initialize(node);
 		}
-		if(FileName!=null)
-			launchSimulation(FileName);
+		launchSimulation();
 		return false;
 	}
 
-	/**
-	 *
-	 * @param path
-	 * path to the json file
-	 */
-	private void launchSimulation(String path) {
-		Scenario scenario;
-		ObjectMapper mapper = new ObjectMapper();
-		try {
-			scenario = mapper.readValue(new File(FileName), Scenario.class);
-		} catch (IOException e) {
-			throw new PpiException("Invalid scenario file", e);
-		}
-		for (ScheduledEvent e : scenario.getEvents()) {
+	private void launchSimulation() {
+		for (ScheduledEvent e : Ppi.getScenario().getEvents()) {
 			EDSimulator.add(e.getDelay(), e, Network.get(e.getNode()), infrapid);
 		}
 	}

--- a/src/main/java/org/sar/ppi/peersim/PeerSimRunner.java
+++ b/src/main/java/org/sar/ppi/peersim/PeerSimRunner.java
@@ -1,6 +1,5 @@
 package org.sar.ppi.peersim;
 
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -9,6 +8,7 @@ import java.nio.file.Paths;
 
 import org.sar.ppi.NodeProcess;
 import org.sar.ppi.Runner;
+import org.sar.ppi.events.Scenario;
 import org.sar.ppi.tools.Utils;
 
 import peersim.Simulator;
@@ -20,7 +20,7 @@ public class PeerSimRunner implements Runner {
 
 	/** {@inheritDoc} */
 	@Override
-	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, File scenario)
+	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, Scenario scenario)
 			throws ReflectiveOperationException {
 		String tmpdir = System.getProperty("java.io.tmpdir");
 		String tmpfile = Paths.get(tmpdir, "ppi-peersim.config").toString();
@@ -29,17 +29,12 @@ public class PeerSimRunner implements Runner {
 		{
 			ClassLoader loader = Thread.currentThread().getContextClassLoader();
 			InputStream base;
-			if(scenario == null)
-				base = loader.getResourceAsStream("peersim.base.conf");
-			else
-				base=loader.getResourceAsStream("peersimSimulate.base.conf");
+			base = loader.getResourceAsStream("peersimSimulate.base.conf");
 			assert base != null;
 			Utils.transferTo(base, os);
 			ps.println();
 			ps.println("protocol.infra.nodeprocess " + pClass.getName());
 			ps.printf("network.size %d\n", nbProcs);
-			if(scenario != null)
-				ps.println("path " + scenario.getAbsolutePath());
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/sar/ppi/tools/Utils.java
+++ b/src/main/java/org/sar/ppi/tools/Utils.java
@@ -3,6 +3,7 @@ package org.sar.ppi.tools;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Array;
 
 public class Utils {
 	public static void transferTo(InputStream in, OutputStream out) throws IOException {
@@ -12,5 +13,29 @@ public class Utils {
 		while ((length = in.read(bytes)) != -1) {
 			out.write(bytes, 0, length);
 		}
+	}
+
+	/**
+	 * Concat all arrays passed into one.
+	 *
+	 * @param <T> The returned array's content's type.
+	 * @param type The returned array's content's type class.
+	 * @param arrays The arrays to concat.
+	 * @return An array containing the values of all those passed in parameter.
+	 */
+	@SafeVarargs
+	@SuppressWarnings("unchecked")
+	public static <T> T[] concatAll(Class<T> type, T[]... arrays) {
+		int totalLength = 0;
+		for (T[] array : arrays) {
+			totalLength += array.length;
+		}
+		T[] result = (T[]) Array.newInstance(type, totalLength);
+		int offset = 0;
+		for (T[] array : arrays) {
+			System.arraycopy(array, 0, result, offset, array.length);
+			offset += array.length;
+		}
+		return result;
 	}
 }

--- a/src/test/java/org/sar/ppi/ArgsTest.java
+++ b/src/test/java/org/sar/ppi/ArgsTest.java
@@ -18,6 +18,7 @@ public class ArgsTest extends RedirectedTest {
 	public void init(String[] args) {
 		if (infra.getId() == 0) {
 			System.out.println(args[0]);
+			System.out.println(args[1]);
 		}
 		infra.exit();
 	}
@@ -25,15 +26,8 @@ public class ArgsTest extends RedirectedTest {
 	@Test
 	public void MpiTest() {
 		Assume.assumeTrue(Environment.mpirunExist());
-		String[] args = {"test"};
+		String[] args = {"test", "test"};
 		Ppi.main(this.getClass(), new MpiRunner(), args, 2);
-		assertEquals("test", outContent.toString().substring(0, 4));
-	}
-
-	@Test
-	public void PeersimTest() {
-		String[] args = {"test"};
-		Ppi.main(this.getClass(), new PeerSimRunner(), args, 2);
 		int i = 0;
 		Scanner scanner = new Scanner(outContent.toString());
 		while (scanner.hasNextLine()) {
@@ -46,5 +40,23 @@ public class ArgsTest extends RedirectedTest {
 			}
 		}
 		assertEquals(2, i);
+	}
+
+	@Test
+	public void PeersimTest() {
+		String[] args = {"test", "test"};
+		Ppi.main(this.getClass(), new PeerSimRunner(), args, 2);
+		int i = 0;
+		Scanner scanner = new Scanner(outContent.toString());
+		while (scanner.hasNextLine()) {
+			String line = scanner.nextLine();
+			if (line.isEmpty()) {
+				continue;
+			} else {
+				i++;
+				assertEquals("test", line);
+			}
+		}
+		assertEquals(4, i);
 	}
 }

--- a/src/test/java/org/sar/ppi/UtilsTest.java
+++ b/src/test/java/org/sar/ppi/UtilsTest.java
@@ -1,0 +1,44 @@
+package org.sar.ppi;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+import org.sar.ppi.tools.Utils;
+
+public class UtilsTest {
+	@Test
+	public void concatAllTestBasic() {
+		String[] a1 = new String[] {"1", "2"};
+		String[] a2 = new String[] {"3"};
+		String[] a3 = new String[] {"4"};
+		String[] expected = new String[] {"1", "2", "3", "4"};
+		assertArrayEquals(expected, Utils.concatAll(String.class, a1, a2, a3));
+	}
+
+	@Test
+	public void concatAllTestInheritance() {
+		Integer[] a1 = new Integer[] {1, 2};
+		Double[] a2 = new Double[] {3d};
+		Float[] a3 = new Float[] {4f};
+		Number[] expected = new Number[] {1, 2, 3d, 4f};
+		assertArrayEquals(expected, Utils.concatAll(Number.class, a1, a2, a3));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void concatAllTestNull() {
+		Integer[] a1 = null;
+		Utils.concatAll(Integer.class, a1);
+	}
+
+	@Test()
+	public void concatAllTestOnlyOne() {
+		Integer[] a1 = new Integer[] {1, 2};
+		assertArrayEquals(a1, Utils.concatAll(Integer.class, a1));
+	}
+
+	@Test()
+	public void concatAllTestNone() {
+		Integer[] expected = new Integer[0];
+		assertArrayEquals(expected, Utils.concatAll(Integer.class));
+	}
+}

--- a/src/test/resources/PredefinedScenarioTest.json
+++ b/src/test/resources/PredefinedScenarioTest.json
@@ -3,7 +3,7 @@
 	"calls": [
 		{
 			"args": [
-				"Arg_1er Appel",
+				"Arg_1er \" Appel\"",
 				4
 			],
 			"node": 0,


### PR DESCRIPTION
Based on #63, so should be merged after ideally.

This adds two important features:

### Ability to directly pass json to the cli

It is now possible to pass a scenario two different ways:
- with a scenario file with `--scenario` option as before
- with a scenario json string `--content` option (yes the name is not reaaly good but I didn't find a better one).

With this feature it is now possible to not have the scenario file on all machines with MPI. It will also allow to directly pass a Scenario object from Java without creating a file (when we will add the ScenarioBuilder).

### Completely abstract Scenario creation for implems

with this feature implems do not have to parse the scenario themselves so it is a good improvement for the ease of creating a new adapter (part of #51).
Also there isn't any null check anymore as the Scenario Object is now always present but it can be empty of events.
