### PR TITLE
chore(tests): automate NodeBreakDownTest

### DIFF
--- a/src/test/java/org/sar/ppi/RedirectedTest.java
+++ b/src/test/java/org/sar/ppi/RedirectedTest.java
@@ -1,7 +1,9 @@
 package org.sar.ppi;
 
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.PrintStream;
+import java.util.Scanner;
 
 import org.junit.After;
 import org.junit.Before;
@@ -12,11 +14,30 @@ public abstract class RedirectedTest extends NodeProcess {
 	protected final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
 	protected final PrintStream originalOut = System.out;
 	protected final PrintStream originalErr = System.err;
+	protected Scanner scanner = null;
+
+	public String nextNonEmpty() throws EOFException {
+		if (scanner == null) {
+			scanner = new Scanner(outContent.toString());
+		}
+		while (scanner.hasNextLine()) {
+			String line = scanner.nextLine();
+			if (!line.isEmpty()) {
+				return line;
+			}
+		}
+		throw new EOFException("No more lines");
+	}
+
+	public boolean hasNextNonEmpty() {
+		return scanner.hasNext("[^\\s]");
+	}
 	
 	@Before
 	public void setUpStreams() {
 		System.setOut(new PrintStream(outContent));
 		System.setErr(new PrintStream(errContent));
+		scanner = null;
 	}
 
 	@After

--- a/src/test/resources/NodeBreakDownTest.json
+++ b/src/test/resources/NodeBreakDownTest.json
@@ -4,8 +4,8 @@
 		{
 			"args": [],
 			"node": 0,
-			"delay": 5000,
-			"function": "End"
+			"delay": 300,
+			"function": "end"
 		}
 	],
 	"undeploys": [


### PR DESCRIPTION
- add 2 functions in RedirectedTest:
  - nextNonEmpty to easily read next line
  - hasNextNonEmpty to easily know if output is empty
- assert NodeBreakdownTest as a UnitTest