### PR TITLE
Infrastructure specific configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,17 +93,17 @@ which can be access via the `infra` property.
 ### CLI reference
 
 ```
-Usage: ppi [-s=<path> | -c=<json>] [-hV] [--np=<number>] <process-class>
+Usage: ppi [-c=<path> | -j=<content>] [-hV] [--np=<number>] <process-class>
            <runner-class> [<args>...]
-      <process-class>     Fully qualified name of the class to use as process
-      <runner-class>      Fully qualified name of the class to use as runner
-      [<args>...]         Args to pass to the processes
-  -c, --content=<json>    Content of the scenario
-  -h, --help              Display a help message
-      --np=<number>       Number of processus in the network
-                            Default: 4
-  -s, --scenario=<path>   Path to the scenario file
-  -V, --version           Print version info
+      <process-class>    Fully qualified name of the class to use as process
+      <runner-class>     Fully qualified name of the class to use as runner
+      [<args>...]        Args to pass to the processes
+  -c, --config=<path>    Path to the config file
+  -h, --help             Display a help message
+  -j, --json=<content>   Content of the config
+      --np=<number>      Number of processus in the network
+                           Default: 4
+  -V, --version          Print version info
 ```
 
 ## Requirement

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
             <enabled>
               <option>DEFINITIONS_FOR_ALL_OBJECTS</option>
               <option>FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT</option>
+              <option>MAP_VALUES_AS_ADDITIONAL_PROPERTIES</option>
             </enabled>
           </options>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
           </execution>
         </executions>
         <configuration>
-          <classNames>${project.groupId}.events.Scenario</classNames>
+          <classNames>${project.groupId}.Config</classNames>
           <modules>
             <module>
               <name>Jackson</name>

--- a/src/main/java/org/sar/ppi/Config.java
+++ b/src/main/java/org/sar/ppi/Config.java
@@ -1,13 +1,17 @@
-package org.sar.ppi.events;
+package org.sar.ppi;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import java.util.Arrays;
+import org.sar.ppi.events.Call;
+import org.sar.ppi.events.Deploy;
+import org.sar.ppi.events.ScheduledEvent;
+import org.sar.ppi.events.Undeploy;
 import org.sar.ppi.tools.PpiUtils;
 
-public class Scenario {
+public class Config {
 	@JsonProperty(value = "$schema", access = JsonProperty.Access.WRITE_ONLY)
 	@SuppressWarnings("PMD.UnusedPrivateField")
 	private String schema = "";
@@ -65,6 +69,6 @@ public class Scenario {
 		String d = Arrays.toString(deploys);
 		String u = Arrays.toString(undeploys);
 		String c = Arrays.toString(calls);
-		return "scenario(deploys:" + d + ", undeploys:" + u + ", calls:" + c + ")";
+		return "config(deploys:" + d + ", undeploys:" + u + ", calls:" + c + ")";
 	}
 }

--- a/src/main/java/org/sar/ppi/Config.java
+++ b/src/main/java/org/sar/ppi/Config.java
@@ -30,6 +30,9 @@ public class Config {
 	@JsonPropertyDescription("Map of infrastructure specific configurations")
 	private Map<String, Map<String, Object>> infra = new HashMap<>();
 
+	@JsonIgnore
+	private String currentInfra = "";
+
 	@JsonSetter("$schema")
 	public void setSchema(String schema) {
 		this.schema = schema;
@@ -63,8 +66,32 @@ public class Config {
 		this.infra = infra;
 	}
 
-	public Map<String, Map<String, Object>> getInfra() {
-		return infra;
+	@JsonIgnore
+	@SuppressWarnings("unchecked")
+	<T> T getInfraProp(String name, String key, T defaultValue) throws ClassCastException {
+		if (infra.containsKey(name) && infra.get(name).containsKey(key)) {
+			return (T) infra.get(name).get(key);
+		}
+		return defaultValue;
+	}
+
+	/**
+	 * Get one of the config properties specific to the current Infrastructure.
+	 *
+	 * @param <T>          the return type of the property.
+	 * @param key          the key of the property.
+	 * @param defaultValue the default value for the property.
+	 * @return             the finale value of the property.
+	 * @throws ClassCastException if the type of the property is incorrect.
+	 */
+	@JsonIgnore
+	public <T> T getInfraProp(String key, T defaultValue) throws ClassCastException {
+		return getInfraProp(currentInfra, key, defaultValue);
+	}
+
+	@JsonIgnore
+	void setCurrentInfra(String currentInfra) {
+		this.currentInfra = currentInfra;
 	}
 
 	@JsonIgnore
@@ -73,8 +100,8 @@ public class Config {
 	}
 
 	@JsonIgnore
-	public boolean isEmpty() {
-		return deploys.length == 0 && undeploys.length == 0 && calls.length == 0;
+	public boolean hasEvents() {
+		return deploys.length > 0 || undeploys.length > 0 || calls.length > 0;
 	}
 
 	@Override

--- a/src/main/java/org/sar/ppi/Config.java
+++ b/src/main/java/org/sar/ppi/Config.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import org.sar.ppi.events.Call;
 import org.sar.ppi.events.Deploy;
 import org.sar.ppi.events.ScheduledEvent;
@@ -24,6 +26,9 @@ public class Config {
 
 	@JsonPropertyDescription("The list of Call events")
 	private Call[] calls = new Call[0];
+
+	@JsonPropertyDescription("Map of infrastructure specific configurations")
+	private Map<String, Map<String, Object>> infra = new HashMap<>();
 
 	@JsonSetter("$schema")
 	public void setSchema(String schema) {
@@ -52,6 +57,14 @@ public class Config {
 
 	public Call[] getCalls() {
 		return calls;
+	}
+
+	public void setInfra(Map<String, Map<String, Object>> infra) {
+		this.infra = infra;
+	}
+
+	public Map<String, Map<String, Object>> getInfra() {
+		return infra;
 	}
 
 	@JsonIgnore

--- a/src/main/java/org/sar/ppi/Ppi.java
+++ b/src/main/java/org/sar/ppi/Ppi.java
@@ -223,8 +223,9 @@ public class Ppi implements Callable<Integer> {
 		Config config
 	)
 		throws PpiException {
+		config.setCurrentInfra(runner.getName());
+		Ppi.config = config;
 		try {
-			Ppi.config = config;
 			runner.run(pClass, args, nbProcs, config);
 		} catch (ReflectiveOperationException e) {
 			throw new PpiException("Failed to intantiate the process class " + pClass.getName(), e);

--- a/src/main/java/org/sar/ppi/Runner.java
+++ b/src/main/java/org/sar/ppi/Runner.java
@@ -5,6 +5,15 @@ package org.sar.ppi;
  */
 public interface Runner {
 	/**
+	 * Get the name of this Runner's Infrastructure.
+	 * This name will be used primarily as the key for this infrastructure's specific
+	 * properties in the config file.
+	 *
+	 * @return the name of this Runner's Infrastructure.
+	 */
+	String getName();
+
+	/**
 	 * Run the runner.
 	 * @param pClass   the class to execute by Ppi.
 	 * @param args     the args to pass to the processes.
@@ -12,6 +21,6 @@ public interface Runner {
 	 * @param config   the config to execute.
 	 * @throws java.lang.ReflectiveOperationException if pClass instanciation fails.
 	 */
-	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, Config config)
+	void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, Config config)
 		throws ReflectiveOperationException;
 }

--- a/src/main/java/org/sar/ppi/Runner.java
+++ b/src/main/java/org/sar/ppi/Runner.java
@@ -1,7 +1,5 @@
 package org.sar.ppi;
 
-import org.sar.ppi.events.Scenario;
-
 /**
  * Runner Interface. It is run by Ppi to start the Infractructure.
  */
@@ -11,9 +9,9 @@ public interface Runner {
 	 * @param pClass   the class to execute by Ppi.
 	 * @param args     the args to pass to the processes.
 	 * @param nbProcs  the number of processes to run.
-	 * @param scenario the scenario to execute.
+	 * @param config   the config to execute.
 	 * @throws java.lang.ReflectiveOperationException if pClass instanciation fails.
 	 */
-	void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, Scenario scenario)
+	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, Config config)
 		throws ReflectiveOperationException;
 }

--- a/src/main/java/org/sar/ppi/mpi/MpiInfrastructure.java
+++ b/src/main/java/org/sar/ppi/mpi/MpiInfrastructure.java
@@ -13,12 +13,12 @@ import mpi.MPIException;
 import mpi.Status;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.sar.ppi.Config;
 import org.sar.ppi.Infrastructure;
 import org.sar.ppi.NodeProcess;
 import org.sar.ppi.PpiException;
 import org.sar.ppi.communication.Message;
 import org.sar.ppi.events.Event;
-import org.sar.ppi.events.Scenario;
 import org.sar.ppi.events.ScheduledEvent;
 
 /**
@@ -32,16 +32,16 @@ public class MpiInfrastructure extends Infrastructure {
 	protected Comm comm;
 	protected Queue<Message> sendQueue = new ConcurrentLinkedQueue<>();
 	protected BlockingQueue<Event> recvQueue = new LinkedBlockingQueue<>();
-	protected Scenario scenario;
+	protected Config config;
 
 	/**
 	 * Constructor for MpiInfrastructure.
 	 *
 	 * @param process a {@link org.sar.ppi.NodeProcess} object.
 	 */
-	public MpiInfrastructure(NodeProcess process, Scenario scenario) {
+	public MpiInfrastructure(NodeProcess process, Config config) {
 		super(process);
-		this.scenario = scenario;
+		this.config = config;
 	}
 
 	/**
@@ -56,7 +56,7 @@ public class MpiInfrastructure extends Infrastructure {
 			MPI.InitThread(args, MPI.THREAD_FUNNELED);
 			comm = MPI.COMM_WORLD;
 			currentNode = comm.getRank();
-			scheduleEvents(scenario);
+			scheduleEvents(config);
 			executor.start();
 			while (running.get() || !sendQueue.isEmpty()) {
 				Status s = comm.iProbe(MPI.ANY_SOURCE, MPI.ANY_TAG);
@@ -162,8 +162,8 @@ public class MpiInfrastructure extends Infrastructure {
 		super.processEvent(e);
 	}
 
-	private void scheduleEvents(Scenario scenario) {
-		for (ScheduledEvent e : scenario.getEvents()) {
+	private void scheduleEvents(Config config) {
+		for (ScheduledEvent e : config.getEvents()) {
 			if (e.getNode() != getId()) {
 				continue;
 			}

--- a/src/main/java/org/sar/ppi/mpi/MpiRunner.java
+++ b/src/main/java/org/sar/ppi/mpi/MpiRunner.java
@@ -19,6 +19,13 @@ import org.sar.ppi.tools.PpiUtils;
  */
 public class MpiRunner implements Runner {
 	private static final Logger LOGGER = LogManager.getLogger();
+	public static final String NAME = "mpi";
+
+	/** {@inheritDoc} */
+	@Override
+	public String getName() {
+		return NAME;
+	}
 
 	/** {@inheritDoc} */
 	@Override

--- a/src/main/java/org/sar/ppi/mpi/MpiRunner.java
+++ b/src/main/java/org/sar/ppi/mpi/MpiRunner.java
@@ -7,11 +7,11 @@ import java.io.InputStreamReader;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.sar.ppi.Config;
 import org.sar.ppi.NodeProcess;
 import org.sar.ppi.Ppi;
 import org.sar.ppi.PpiException;
 import org.sar.ppi.Runner;
-import org.sar.ppi.events.Scenario;
 import org.sar.ppi.tools.PpiUtils;
 
 /**
@@ -22,20 +22,15 @@ public class MpiRunner implements Runner {
 
 	/** {@inheritDoc} */
 	@Override
-	public void run(
-		Class<? extends NodeProcess> pClass,
-		String[] args,
-		int nbProcs,
-		Scenario scenario
-	)
+	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, Config config)
 		throws PpiException {
-		String scenarioJson;
+		String configJson;
 		String s = null;
 		boolean err = false;
 		try {
-			scenarioJson = Ppi.getMapper().writeValueAsString(scenario);
+			configJson = Ppi.getMapper().writeValueAsString(config);
 		} catch (JsonProcessingException e) {
-			throw new PpiException("Could not serialize this scenario", e);
+			throw new PpiException("Could not serialize this config", e);
 		}
 		String[] cmdline = new String[] {
 			"mpirun",
@@ -49,7 +44,7 @@ public class MpiRunner implements Runner {
 			pClass.getName(),
 			MpiSubRunner.class.getName(),
 			"--np=" + nbProcs,
-			"-c=" + scenarioJson
+			"-j=" + configJson
 		};
 		cmdline = PpiUtils.concatAll(String.class, cmdline, args);
 		LOGGER.debug("mpi cmdline: {}", String.join(" ", cmdline));

--- a/src/main/java/org/sar/ppi/mpi/MpiSubRunner.java
+++ b/src/main/java/org/sar/ppi/mpi/MpiSubRunner.java
@@ -1,8 +1,8 @@
 package org.sar.ppi.mpi;
 
+import org.sar.ppi.Config;
 import org.sar.ppi.NodeProcess;
 import org.sar.ppi.Runner;
-import org.sar.ppi.events.Scenario;
 
 /**
  * MpiSubRunner class.
@@ -11,16 +11,11 @@ public class MpiSubRunner implements Runner {
 
 	/** {@inheritDoc} */
 	@Override
-	public void run(
-		Class<? extends NodeProcess> pClass,
-		String[] args,
-		int nbProcs,
-		Scenario scenario
-	)
+	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, Config config)
 		throws ReflectiveOperationException {
 		NodeProcess process = pClass.newInstance();
 		MpiInfrastructure infra;
-		infra = new MpiInfrastructure(process, scenario);
+		infra = new MpiInfrastructure(process, config);
 		process.setInfra(infra);
 		infra.run(args);
 	}

--- a/src/main/java/org/sar/ppi/mpi/MpiSubRunner.java
+++ b/src/main/java/org/sar/ppi/mpi/MpiSubRunner.java
@@ -11,6 +11,12 @@ public class MpiSubRunner implements Runner {
 
 	/** {@inheritDoc} */
 	@Override
+	public String getName() {
+		return MpiRunner.NAME;
+	}
+
+	/** {@inheritDoc} */
+	@Override
 	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, Config config)
 		throws ReflectiveOperationException {
 		NodeProcess process = pClass.newInstance();

--- a/src/main/java/org/sar/ppi/peersim/PeerSimInfrastructure.java
+++ b/src/main/java/org/sar/ppi/peersim/PeerSimInfrastructure.java
@@ -90,7 +90,6 @@ public class PeerSimInfrastructure extends Infrastructure implements EDProtocol,
 	/** {@inheritDoc} */
 	@Override
 	public int getId() {
-		// TODO Auto-generated method stub
 		return super.getId() % Network.size();
 	}
 

--- a/src/main/java/org/sar/ppi/peersim/PeerSimInit.java
+++ b/src/main/java/org/sar/ppi/peersim/PeerSimInit.java
@@ -43,7 +43,7 @@ public class PeerSimInit implements Control {
 	}
 
 	private void launchSimulation() {
-		for (ScheduledEvent e : Ppi.getScenario().getEvents()) {
+		for (ScheduledEvent e : Ppi.getConfig().getEvents()) {
 			EDSimulator.add(e.getDelay(), e, Network.get(e.getNode()), infraPid);
 		}
 	}

--- a/src/main/java/org/sar/ppi/peersim/PeerSimRunner.java
+++ b/src/main/java/org/sar/ppi/peersim/PeerSimRunner.java
@@ -5,6 +5,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.file.Paths;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.sar.ppi.Config;
 import org.sar.ppi.NodeProcess;
 import org.sar.ppi.Runner;
@@ -15,6 +17,14 @@ import peersim.Simulator;
  * PeerSimRunner class.
  */
 public class PeerSimRunner implements Runner {
+	private static final Logger LOGGER = LogManager.getLogger();
+	public static final String NAME = "peersim";
+
+	/** {@inheritDoc} */
+	@Override
+	public String getName() {
+		return NAME;
+	}
 
 	/** {@inheritDoc} */
 	@Override
@@ -22,6 +32,7 @@ public class PeerSimRunner implements Runner {
 		throws ReflectiveOperationException {
 		String tmpdir = System.getProperty("java.io.tmpdir");
 		String tmpfile = Paths.get(tmpdir, "ppi-peersim.config").toString();
+		LOGGER.debug("peersim config file: '{}'", config.getInfraProp("configFile", ""));
 		try (
 			OutputStream os = new FileOutputStream(tmpfile);
 			PrintStream ps = new PrintStream(os)

--- a/src/main/java/org/sar/ppi/peersim/PeerSimRunner.java
+++ b/src/main/java/org/sar/ppi/peersim/PeerSimRunner.java
@@ -5,9 +5,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.file.Paths;
+import org.sar.ppi.Config;
 import org.sar.ppi.NodeProcess;
 import org.sar.ppi.Runner;
-import org.sar.ppi.events.Scenario;
 import org.sar.ppi.tools.PpiUtils;
 import peersim.Simulator;
 
@@ -18,12 +18,7 @@ public class PeerSimRunner implements Runner {
 
 	/** {@inheritDoc} */
 	@Override
-	public void run(
-		Class<? extends NodeProcess> pClass,
-		String[] args,
-		int nbProcs,
-		Scenario scenario
-	)
+	public void run(Class<? extends NodeProcess> pClass, String[] args, int nbProcs, Config config)
 		throws ReflectiveOperationException {
 		String tmpdir = System.getProperty("java.io.tmpdir");
 		String tmpfile = Paths.get(tmpdir, "ppi-peersim.config").toString();

--- a/src/test/resources/HelloRingScenarioTest.json
+++ b/src/test/resources/HelloRingScenarioTest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "../../../target/Scenario-schema.json",
+	"$schema": "../../../target/Config-schema.json",
 	"calls": [
 		{
 			"args": [],

--- a/src/test/resources/HelloRingScenarioTest.json
+++ b/src/test/resources/HelloRingScenarioTest.json
@@ -13,5 +13,10 @@
 			"delay": 1000000,
 			"function": "end"
 		}
-	]
+	],
+	"infra": {
+		"peersim": {
+			"configFile": "peersim.properties"
+		}
+	}
 }

--- a/src/test/resources/MutexTest.json
+++ b/src/test/resources/MutexTest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "../../../target/Scenario-schema.json",
+	"$schema": "../../../target/Config-schema.json",
 	"undeploys": [],
 	"calls": [
 		{

--- a/src/test/resources/NodeBreakDownTest.json
+++ b/src/test/resources/NodeBreakDownTest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "../../../target/Scenario-schema.json",
+	"$schema": "../../../target/Config-schema.json",
 	"calls": [
 		{
 			"args": [],

--- a/src/test/resources/PredefinedScenarioTest.json
+++ b/src/test/resources/PredefinedScenarioTest.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "../../../target/Scenario-schema.json",
+	"$schema": "../../../target/Config-schema.json",
 	"calls": [
 		{
 			"args": [


### PR DESCRIPTION
This Pull request adds 2 changes:

### Rename Scenario into Config

As the json file now contains more configuration than just the scenario I renamed the corresponding class into `Config`.
Applies changes from https://github.com/PolyProcessInterface/ppi/pull/70#issuecomment-645630633

### Infrastructure specific configuration

With these changes an infrastructure can easily read parameters specific to it.
It can define its key under the `"infra"` json object by implementing the `Runner.getName()` function then it can read a property with the following function of `Config`:
```java
public <T> T getInfraProp(String key, T defaultValue) throws ClassCastException
```

Here is a usage exemple:
https://github.com/PolyProcessInterface/ppi/blob/144bcad141379d8a82437e11177dc98b23fe97ba/src/main/java/org/sar/ppi/peersim/PeerSimRunner.java#L35

Resolves #74 